### PR TITLE
Add information about how to use the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # Open Graph app
 
-An app to give your Site support for Open Graph meta data, automatically extracted from current content (if possible) with possibility to define some default fallbacks.
+This Enonic XP application adds [Open Graph](http://ogp.me/) meta-tags to your
+site by applying mixin fields to each content (or as a site-wide setting). This
+is a great way to improve your SEO and social sharing presence.
+
+## Usage
+
+Clone this project, deploy it to your server and add the `Opengraph App`
+application to your site. You should now see `SEO Metadata` fields on both
+your site and on all of your contents. We select the information to use based on
+the following:
+
+### For title and description
+
+- If a content has a SEO title or description field filled out, we use that
+- If not, but the content has a `displayName` (title) or
+`[preface, description, summary]` (description) field, we fall back to those
+fields.
+- If not, but the site itself has the SEO Metadata fields filled out, we fall
+back to those fields.
+- As a last resort, we default to the site's name and description fields.
+
+### For images
+- If a content has a `image` or `images` ContentSelector, we use that
+- If not, but the Opengraph app has been set up with a default image for the
+site in question, we fall back to that image (your logo for example).
+- If neither is set, we don't show an image (the tags are not added).
 
 ## Important TODO
 


### PR DESCRIPTION
Although the application works well, it's poorly documented. This patch
tries to explain to the user how to install and use this plugin, as well
as how the fallback solutions work.

We should probably also remove the todos from the README and add it to GitHub issues, since that works better with comments and feature requests from users.

cc @Bellfalasch